### PR TITLE
The development and production URL are not the same

### DIFF
--- a/login-module/src/constants.js
+++ b/login-module/src/constants.js
@@ -1,5 +1,4 @@
 export default {
-	getApiBaseUrl: (stage) => {
-		return `https://nmae7t4ami.execute-api.us-east-1.amazonaws.com/${stage || 'prod'}`;
-	}
+  getApiBaseUrl: (stage) => stage === 'dev' ? 'https://9niagofhzb.execute-api.us-east-1.amazonaws.com/dev' 
+                                            : 'https://nmae7t4ami.execute-api.us-east-1.amazonaws.com/prod'
 }


### PR DESCRIPTION
Are you sure about this change? Previously the URL were:

* dev: https://9niagofhzb.execute-api.us-east-1.amazonaws.com/dev
* prod: https://nmae7t4ami.execute-api.us-east-1.amazonaws.com/prod