### PR TITLE
Append part-0/ after pathname (not at the end of the URL)

### DIFF
--- a/Courses/_lib/src/enrollment.js
+++ b/Courses/_lib/src/enrollment.js
@@ -5,7 +5,8 @@ window.intercomSettings = {
 }
 
 ;(function ($) {
-  var siteUrl = window.location
+  var location = window.location
+  var siteUrl = location.href
   var trainingLogoutEvent = window.trainingLogoutEvent
   var trainingLoginEvent = window.trainingLoginEvent
   var trainingRegisterEvent = window.trainingRegisterEvent
@@ -13,7 +14,7 @@ window.intercomSettings = {
   var backendBaseUrl = "{{API_BASE_URL}}"
   var trainingName = window.trainingClassName
   // 2020-05-22 - temporary default value to ease the migration
-  var trainingCourseUrl = window.trainingCourseUrl || (siteUrl + 'part-0/')
+  var trainingCourseUrl = window.trainingCourseUrl || (location.origin + location.pathname + 'part-0/' + location.search + location.hash)
 
   function getEnrollmentForClass(accessToken) {
     return $.ajax({


### PR DESCRIPTION
Otherwise, we will produce invalid URL when the URL contains query parameters and/or hash.
For instance: `https://neo4j.com/graphacademy/online-training/introduction-to-neo4j/?ref=social-camp`

```diff
-https://neo4j.com/graphacademy/online-training/introduction-to-neo4j/?ref=social-camp/part-0/
+https://neo4j.com/graphacademy/online-training/introduction-to-neo4j/part-0/?ref=social-camp
```