### PR TITLE
resolves #64 remove boostrap.min.js

### DIFF
--- a/Courses/_templates/course/document.html.erb
+++ b/Courses/_templates/course/document.html.erb
@@ -31,7 +31,6 @@
         }
       </style>
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js" type="text/javascript"></script>
-      <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" type="text/javascript"></script>
       <link rel="shortcut icon" href="https://neo4j.com/wp-content/themes/neo4jweb/favicon.ico"></link>
       <script type='text/javascript' src='https://neo4j.com/wp-content/themes/neo4jweb/assets/js/vendor/codemirror.min.js?ver=4.5.2'></script>
       <script type='text/javascript'>


### PR DESCRIPTION
We can publish a course with this change to make sure this is script is not used anymore.
The only reference I found was in the (now removed) gadget.js script where we were using the `modal()`: https://getbootstrap.com/docs/3.3/javascript/#modals


resolves #64