### PR TITLE
Fix queries using WITH * in Applied Graph Algorithms training

### DIFF
--- a/Courses/AppliedGraphAlgorithms/react-app/src/exercises/exercise0.js
+++ b/Courses/AppliedGraphAlgorithms/react-app/src/exercises/exercise0.js
@@ -3,7 +3,7 @@ MATCH (u:User {id: $userId})
 MATCH (u)-[:WROTE]->(r:Review)
 WITH u, avg(r.stars) AS averageStars
 MATCH (u)-[:WROTE]->(:Review)-[:REVIEWS]->(:Business)-[:IN_CATEGORY]-(c:Category)
-WITH *, c.name AS category, COUNT(*) AS num ORDER BY num DESC
+WITH u, averageStars, c.name AS category, COUNT(*) AS num ORDER BY num DESC
 RETURN u {
   .name, 
   numReviews: toFloat(SIZE((u)-[:WROTE]->(:Review))), 

--- a/Courses/AppliedGraphAlgorithms/react-app/src/exercises/exercise2.js
+++ b/Courses/AppliedGraphAlgorithms/react-app/src/exercises/exercise2.js
@@ -8,6 +8,6 @@ WITH node AS b ORDER BY score DESC LIMIT 200
 MATCH (b)-[:IN_CATEGORY]->(c:Category {name: $category})
 OPTIONAL MATCH (b)-[:HAS_PHOTO]->(p:Photo)
 WITH b, COLLECT(p)[0] AS p
-WITH * ORDER BY EXISTS((b)-[:HAS_PHOTO]->()) DESC LIMIT 100
+WITH b,p ORDER BY EXISTS((b)-[:HAS_PHOTO]->()) DESC LIMIT 100
 RETURN COLLECT(b {.*, photo: p.id}) AS businesses
 `;

--- a/Courses/AppliedGraphAlgorithms/react-app/src/solutions/exercise0.js
+++ b/Courses/AppliedGraphAlgorithms/react-app/src/solutions/exercise0.js
@@ -3,7 +3,7 @@ MATCH (u:User {id: $userId})
 MATCH (u)-[:WROTE]->(r:Review)
 WITH u, avg(r.stars) AS averageStars
 MATCH (u)-[:WROTE]->(:Review)-[:REVIEWS]->(:Business)-[:IN_CATEGORY]-(c:Category)
-WITH *, c.name AS category, COUNT(*) AS num ORDER BY num DESC
+WITH u, averageStars, c.name AS category, COUNT(*) AS num ORDER BY num DESC
 RETURN u {
   .name, 
   numReviews: toFloat(SIZE((u)-[:WROTE]->(:Review))), 


### PR DESCRIPTION
There seems to be a Cypher issue when using ORDER BY and WITH * together that was introduced in more recent versions of Neo4j 3.5. See the Trello card [here](https://trello.com/c/BFC3cMAc/3291-bug-using-order-by-and-with) to track this issue.

This PR removes the use of the `WITH *` syntax in the Applied Graph Algorithms training.